### PR TITLE
Add pedsim_sensors/point_cloud.cpp: (pointcloud with occlusion)

### DIFF
--- a/pedsim_sensors/CMakeLists.txt
+++ b/pedsim_sensors/CMakeLists.txt
@@ -39,7 +39,11 @@ add_executable(${OBSTACLE_PCD_EXEC_NAME} src/pedsim_sensors/obstacle_point_cloud
 add_dependencies(${OBSTACLE_PCD_EXEC_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${OBSTACLE_PCD_EXEC_NAME} ${catkin_LIBRARIES})
 
-
+# Point cloud sensor.
+set(PCD_EXEC_NAME pedsim_sensor)
+add_executable(${PCD_EXEC_NAME} src/pedsim_sensors/point_cloud.cpp)
+add_dependencies(${PCD_EXEC_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PCD_EXEC_NAME} ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -49,6 +53,7 @@ install(
   TARGETS
     ${PEOPLE_PCD_EXEC_NAME}
     ${OBSTACLE_PCD_EXEC_NAME}
+    ${PCD_EXEC_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/pedsim_sensors/include/pedsim_sensors/point_cloud.h
+++ b/pedsim_sensors/include/pedsim_sensors/point_cloud.h
@@ -1,0 +1,78 @@
+/**
+* Copyright 2014- Social Robotics Lab, University of Freiburg
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+*    # Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*    # Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*    # Neither the name of the University of Freiburg nor the names of its
+*       contributors may be used to endorse or promote products derived from
+*       this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*
+* \author Billy Okal <okal@cs.uni-freiburg.de>
+*/
+
+#ifndef POINT_CLOUD_H
+#define POINT_CLOUD_H
+
+#include <pedsim_sensors/pedsim_sensor.h>
+
+#include <queue>
+
+#include <pedsim_msgs/LineObstacles.h>
+#include <pedsim_msgs/AgentStates.h>
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud.h>
+#include <sensor_msgs/point_cloud_conversion.h>
+
+namespace pedsim_ros {
+
+class PointCloud : public PedsimSensor {
+ public:
+  PointCloud(const ros::NodeHandle& node_handle, const double rate, const int resol, 
+                     const FoVPtr& fov);
+  virtual ~PointCloud() = default;
+
+  void broadcast() override;
+  void run();
+  void obstaclesCallBack(const pedsim_msgs::LineObstaclesConstPtr& obstacles);
+  void agentStatesCallBack(const pedsim_msgs::AgentStatesConstPtr& agents);
+
+  // detected obss is a 360 deg scan map
+  uint rad_to_index(float rad);
+  float index_to_rad(uint index);
+  void fillDetectedObss(std::vector<std::complex<float>>& detected_obss,
+                        std::complex<float> obs, float width);
+
+ private:
+  ros::Subscriber sub_simulated_obstacles_;
+  ros::Subscriber sub_simulated_agents_;
+
+  std::queue<pedsim_msgs::LineObstaclesConstPtr> q_obstacles_;
+  std::queue<pedsim_msgs::AgentStatesConstPtr> q_agents_;
+
+ protected:
+  int resol_;
+  float human_width = 0.2;
+  float obs_width = 0.5;
+};
+
+}  // namespace pedsim_ros
+
+#endif

--- a/pedsim_sensors/launch/pcd_sensor.launch
+++ b/pedsim_sensors/launch/pcd_sensor.launch
@@ -1,0 +1,16 @@
+<launch>
+  <arg name="range" default="10.0"/>
+  <arg name="resol" default="360"/>
+  <arg name="origin_x" default="0.0"/>
+  <arg name="origin_y" default="0.0"/>
+
+  <!-- main simulator node -->
+  <node name="pedsim_sensor" pkg="pedsim_sensors" type="pedsim_sensor" output="screen">
+    <param name="pose_initial_x" value="$(arg origin_x)"/>
+    <param name="pose_initial_y" value="$(arg origin_y)"/>
+    <param name="fov_range" value="$(arg range)" type="double"/>
+    <param name="rate" value="25.0" type="double"/>
+    <param name="resol" value="$(arg resol)" type="int"/>
+  </node>
+
+</launch>

--- a/pedsim_sensors/src/pedsim_sensors/obstacle_point_cloud.cpp
+++ b/pedsim_sensors/src/pedsim_sensors/obstacle_point_cloud.cpp
@@ -55,7 +55,7 @@ void ObstaclePointCloud::broadcast() {
 
   const auto sim_obstacles = q_obstacles_.front();
 
-  using Cell = std::pair<float, float>;
+  using Cell = std::complex<float>;
   std::vector<Cell> all_cells;
   for (const auto& line : sim_obstacles->obstacles) {
     const auto cells = pedsim::LineObstacleToCells(line.start.x, line.start.y,
@@ -108,9 +108,9 @@ void ObstaclePointCloud::broadcast() {
     const int cell_color = color_distribution(generator);
 
     for (size_t j = 0; j < point_density; ++j) {
-      if (fov_->inside(cell.first, cell.second)) {
-        const tf::Vector3 point(cell.first + width_distribution(generator),
-                                cell.second + width_distribution(generator),
+      if (fov_->inside(cell.real(), cell.imag())) {
+        const tf::Vector3 point(cell.real() + width_distribution(generator),
+                                cell.imag() + width_distribution(generator),
                                 0.);
         const auto transformed_point = transformPoint(robot_transform, point);
 
@@ -120,9 +120,9 @@ void ObstaclePointCloud::broadcast() {
         pcd_local.channels[0].values[index] = cell_color;
 
         // Global observations.
-        pcd_global.points[index].x = cell.first + width_distribution(generator);
+        pcd_global.points[index].x = cell.real() + width_distribution(generator);
         pcd_global.points[index].y =
-            cell.second + width_distribution(generator);
+            cell.imag() + width_distribution(generator);
         pcd_global.points[index].z = height_distribution(generator);
         pcd_global.channels[0].values[index] = cell_color;
       }

--- a/pedsim_sensors/src/pedsim_sensors/point_cloud.cpp
+++ b/pedsim_sensors/src/pedsim_sensors/point_cloud.cpp
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2014- Social Robotics Lab, University of Freiburg
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    # Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *    # Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *    # Neither the name of the University of Freiburg nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \author Billy Okal <okal@cs.uni-freiburg.de>
+ */
+
+#include <pedsim_sensors/point_cloud.h>
+#include <pedsim_utils/geometry.h>
+#include <math.h>
+#include <random>
+#define INF 100000000
+
+namespace pedsim_ros {
+
+using Cell = std::complex<float>;
+
+PointCloud::PointCloud(const ros::NodeHandle& node_handle,
+                            const double rate, const int resol, const FoVPtr& fov)
+    : PedsimSensor(node_handle, rate, fov) {
+  resol_ = resol;
+  pub_signals_local_ =
+      nh_.advertise<sensor_msgs::PointCloud>("point_cloud_local", 1);
+  pub_signals_global_ =
+      nh_.advertise<sensor_msgs::PointCloud>("point_cloud_global", 1);
+
+  sub_simulated_obstacles_ =
+      nh_.subscribe("/pedsim_simulator/simulated_walls", 1,
+                    &PointCloud::obstaclesCallBack, this);
+  sub_simulated_agents_ =
+      nh_.subscribe("/pedsim_simulator/simulated_agents", 1,
+                    &PointCloud::agentStatesCallBack, this);
+}
+
+uint PointCloud::rad_to_index(float rad_){
+  auto rad = atan2(sin(rad_), cos(rad_));
+  return (rad + M_PI) * resol_ / (2 * M_PI);
+}
+
+float PointCloud::index_to_rad(uint index){
+  return -M_PI + 2 * M_PI / resol_ * index;
+}
+
+void PointCloud::fillDetectedObss(std::vector<Cell>& detected_obss, Cell cell, float width){
+  Cell obs = cell - Cell(fov_->origin_x, fov_->origin_y);
+  for (float edge : {-width, width}){
+    for (float dw = -width; dw <= width; dw += width / 10) {
+      for (auto new_obs : {obs + Cell(edge, dw), obs + Cell(dw, edge)}){
+        auto r = std::abs(new_obs);
+        auto theta = std::arg(new_obs);
+        uint index = rad_to_index(theta);
+        if (r < std::abs(detected_obss[index])) {
+          auto polar = std::polar(r, theta);
+          detected_obss[index] = polar;
+        }
+      }
+    }
+  }
+}
+
+void PointCloud::broadcast() {
+
+  std::vector<Cell> detected_obss(resol_, Cell(INF, INF));
+
+  // obstacles 
+  if (q_obstacles_.size() < 1 || q_agents_.size() < 1) {
+    return;
+  }
+
+  // fill by cells
+  std::vector<Cell> all_cells;
+  const auto sim_obstacles = q_obstacles_.front();
+  for (const auto& line : sim_obstacles->obstacles) {
+    const auto cells = pedsim::LineObstacleToCells(line.start.x, line.start.y,
+                                                   line.end.x, line.end.y);
+    std::copy(cells.begin(), cells.end(), std::back_inserter(all_cells));
+  }
+  for (const auto& cell : all_cells) {
+    fillDetectedObss(detected_obss, cell, obs_width);
+  }
+
+  // fill by agents
+  const auto people_signal = q_agents_.front();
+  for (const auto& person : people_signal->agent_states) {
+    Cell cell(person.pose.position.x, person.pose.position.y);
+    fillDetectedObss(detected_obss, cell, human_width);
+  }
+
+  constexpr int point_density = 5;
+  const int num_points = detected_obss.size() * point_density;
+
+  std::default_random_engine generator;
+
+  // \todo - Read params from config file.
+  std::uniform_int_distribution<int> color_distribution(1, 255);
+  std::uniform_real_distribution<float> height_distribution(0, 1);
+  std::uniform_real_distribution<float> width_distribution(-0.05, 0.05);
+
+  sensor_msgs::PointCloud pcd_global;
+  pcd_global.header.stamp = ros::Time::now();
+  pcd_global.header.frame_id = sim_obstacles->header.frame_id;
+  pcd_global.points.resize(num_points);
+  pcd_global.channels.resize(1);
+  pcd_global.channels[0].name = "intensities";
+  pcd_global.channels[0].values.resize(num_points);
+
+  sensor_msgs::PointCloud pcd_local;
+  pcd_local.header.stamp = ros::Time::now();
+  pcd_local.header.frame_id = robot_odom_.header.frame_id;
+  pcd_local.points.resize(num_points);
+  pcd_local.channels.resize(1);
+  pcd_local.channels[0].name = "intensities";
+  pcd_local.channels[0].values.resize(num_points);
+
+  // prepare the transform to robot odom frame.
+  tf::StampedTransform robot_transform;
+  try {
+    transform_listener_->lookupTransform(robot_odom_.header.frame_id,
+                                         sim_obstacles->header.frame_id,
+                                         ros::Time(0), robot_transform);
+  } catch (tf::TransformException& e) {
+    ROS_WARN_STREAM_THROTTLE(5.0, "TFP lookup from ["
+                                      << sim_obstacles->header.frame_id
+                                      << "] to [" << robot_odom_.header.frame_id
+                                      << "] failed. Reason: " << e.what());
+    return;
+  }
+
+  size_t index = 0;
+  for (const auto& obs : detected_obss) {
+    Cell cell = obs + Cell(fov_->origin_x, fov_->origin_y);
+    const int cell_color = color_distribution(generator);
+
+    for (size_t j = 0; j < point_density; ++j) {
+      if (fov_->inside(cell.real(), cell.imag())) {
+        const tf::Vector3 point(cell.real() + width_distribution(generator),
+                                cell.imag() + width_distribution(generator),
+                                0.);
+        const auto transformed_point = transformPoint(robot_transform, point);
+
+        pcd_local.points[index].x = transformed_point.getOrigin().x();
+        pcd_local.points[index].y = transformed_point.getOrigin().y();
+        pcd_local.points[index].z = height_distribution(generator);
+        pcd_local.channels[0].values[index] = cell_color;
+
+        // Global observations.
+        pcd_global.points[index].x = cell.real() + width_distribution(generator);
+        pcd_global.points[index].y =
+            cell.imag() + width_distribution(generator);
+        pcd_global.points[index].z = height_distribution(generator);
+        pcd_global.channels[0].values[index] = cell_color;
+      }
+
+      index++;
+    }
+  }
+
+  if (pcd_local.channels[0].values.size() > 1) {
+    pub_signals_local_.publish(pcd_local);
+  }
+  if (pcd_global.channels[0].values.size() > 1) {
+    pub_signals_global_.publish(pcd_global);
+  }
+
+  q_obstacles_.pop();
+  q_agents_.pop();
+};
+
+void PointCloud::run() {
+  ros::Rate r(rate_);
+
+  while (ros::ok()) {
+    broadcast();
+
+    ros::spinOnce();
+    r.sleep();
+  }
+}
+
+void PointCloud::obstaclesCallBack(
+    const pedsim_msgs::LineObstaclesConstPtr& obstacles) {
+  q_obstacles_.emplace(obstacles);
+}
+
+void PointCloud::agentStatesCallBack(
+    const pedsim_msgs::AgentStatesConstPtr& agents) {
+  q_agents_.emplace(agents);
+}
+
+}  // namespace pedsim_ros
+
+// --------------------------------------------------------------
+
+int main(int argc, char** argv) {
+  ros::init(argc, argv, "pedsim_obstacle_sensor");
+  ros::NodeHandle node("~");
+
+  double init_x = 0.0, init_y = 0.0, fov_range = 0.0;
+  node.param<double>("pose_initial_x", init_x, 0.0);
+  node.param<double>("pose_initial_y", init_y, 0.0);
+  node.param<double>("fov_range", fov_range, 15.);
+
+  pedsim_ros::FoVPtr circle_fov;
+  circle_fov.reset(new pedsim_ros::CircularFov(init_x, init_y, fov_range));
+
+  double sensor_rate = 0.0;
+  int sensor_resol = 360;
+  node.param<double>("rate", sensor_rate, 25.0);
+  node.param<int>("resol", sensor_resol, 360);
+
+  pedsim_ros::PointCloud pcd_sensor(node, sensor_rate, sensor_resol, circle_fov);
+  ROS_INFO_STREAM("Initialized obstacle PCD sensor with center: ("
+                  << init_x << ", " << init_y << ") , range: " << fov_range << ", resolution: " << sensor_resol);
+
+  pcd_sensor.run();
+  return 0;
+}

--- a/pedsim_simulator/src/simulator.cpp
+++ b/pedsim_simulator/src/simulator.cpp
@@ -128,8 +128,9 @@ bool Simulator::initializeSimulation() {
 
 void Simulator::runSimulation() {
   ros::Rate r(CONFIG.updateRate);
+
   while (ros::ok()) {
-    if (SCENE.getTime() < 0.1) {
+    if (!robot_) {
       // setup the robot
       for (Agent* agent : SCENE.getAgents()) {
         if (agent->getType() == Ped::Tagent::ROBOT) {

--- a/pedsim_utils/include/pedsim_utils/geometry.h
+++ b/pedsim_utils/include/pedsim_utils/geometry.h
@@ -16,7 +16,7 @@ geometry_msgs::Quaternion toQuaternionMsg(const Eigen::Quaternionf& quaternion);
 
 geometry_msgs::Quaternion poseFrom2DVelocity(const double vx, const double vy);
 
-std::vector<std::pair<float, float>> LineObstacleToCells(const float x1,
+std::vector<std::complex<float>> LineObstacleToCells(const float x1,
                                                          const float y1,
                                                          const float x2,
                                                          const float y2);

--- a/pedsim_utils/src/pedsim_utils/geometry.cpp
+++ b/pedsim_utils/src/pedsim_utils/geometry.cpp
@@ -43,7 +43,7 @@ geometry_msgs::Quaternion poseFrom2DVelocity(const double vx, const double vy) {
   return rpyToQuaternion(M_PI / 2.0, theta + (M_PI / 2.0), 0.0);
 }
 
-std::vector<std::pair<float, float>> LineObstacleToCells(const float x1,
+std::vector<std::complex<float>> LineObstacleToCells(const float x1,
                                                          const float y1,
                                                          const float x2,
                                                          const float y2) {
@@ -76,8 +76,8 @@ std::vector<std::pair<float, float>> LineObstacleToCells(const float x1,
   ddy = 2 * dy;  // work with double values for full precision
   ddx = 2 * dx;
 
-  std::vector<std::pair<float, float>> obstacle_cells;  // TODO - reserve.
-  obstacle_cells.emplace_back(std::make_pair(x, y));
+  std::vector<std::complex<float>> obstacle_cells;  // TODO - reserve.
+  obstacle_cells.emplace_back(std::complex<float>(x, y));
 
   if (ddx >= ddy) {
     // first octant (0 <= slope <= 1)
@@ -95,17 +95,17 @@ std::vector<std::pair<float, float>> LineObstacleToCells(const float x1,
         // below):
         if (error + errorprev < ddx) {
           // bottom square also
-          obstacle_cells.emplace_back(std::make_pair(x, y - ystep));
+          obstacle_cells.emplace_back(std::complex<float>(x, y - ystep));
         } else if (error + errorprev > ddx) {
           // left square also
-          obstacle_cells.emplace_back(std::make_pair(x - xstep, y));
+          obstacle_cells.emplace_back(std::complex<float>(x - xstep, y));
         } else {
           // corner: bottom and left squares also
-          obstacle_cells.emplace_back(std::make_pair(x, y - ystep));
-          obstacle_cells.emplace_back(std::make_pair(x - xstep, y));
+          obstacle_cells.emplace_back(std::complex<float>(x, y - ystep));
+          obstacle_cells.emplace_back(std::complex<float>(x - xstep, y));
         }
       }
-      obstacle_cells.emplace_back(std::make_pair(x, y));
+      obstacle_cells.emplace_back(std::complex<float>(x, y));
       errorprev = error;
     }
   } else {
@@ -118,15 +118,15 @@ std::vector<std::pair<float, float>> LineObstacleToCells(const float x1,
         x += xstep;
         error -= ddy;
         if (error + errorprev < ddy) {
-          obstacle_cells.emplace_back(std::make_pair(x - xstep, y));
+          obstacle_cells.emplace_back(std::complex<float>(x - xstep, y));
         } else if (error + errorprev > ddy) {
-          obstacle_cells.emplace_back(std::make_pair(x, y - ystep));
+          obstacle_cells.emplace_back(std::complex<float>(x, y - ystep));
         } else {
-          obstacle_cells.emplace_back(std::make_pair(x, y - ystep));
-          obstacle_cells.emplace_back(std::make_pair(x - xstep, y));
+          obstacle_cells.emplace_back(std::complex<float>(x, y - ystep));
+          obstacle_cells.emplace_back(std::complex<float>(x - xstep, y));
         }
       }
-      obstacle_cells.emplace_back(std::make_pair(x, y));
+      obstacle_cells.emplace_back(std::complex<float>(x, y));
       errorprev = error;
     }
   }

--- a/pedsim_visualizer/src/sim_visualizer.cpp
+++ b/pedsim_visualizer/src/sim_visualizer.cpp
@@ -168,8 +168,8 @@ void SimVisualizer::publishObstacleVisuals() {
     for (const auto& cell : LineObstacleToCells(line.start.x, line.start.y,
                                                 line.end.x, line.end.y)) {
       geometry_msgs::Point p;
-      p.x = cell.first;
-      p.y = cell.second;
+      p.x = cell.real();
+      p.y = cell.imag();
       p.z = 0.0;
       walls_marker.points.push_back(p);
     }


### PR DESCRIPTION
Hi,

Since the original pedsim_sensors doesn't consider occlusion, I add a point_cloud.cpp, which publishes occluded people and obstacles pointcloud. 
Try it by 
```
roslaunch pedsim_sensors  pedsim_sensor.launch
```

![rviz_screenshot_2019_12_01-02_46_05](https://user-images.githubusercontent.com/29631982/69908589-495c6880-1430-11ea-91ae-7132c46d8165.png)
