### PR TITLE
Fixed gazebo's 3D model shaking problem.

### DIFF
--- a/pedsim_gazebo_plugin/models/actor_model.sdf
+++ b/pedsim_gazebo_plugin/models/actor_model.sdf
@@ -2,30 +2,30 @@
 <sdf version="1.5">
 
 
-<model name="actor_model">
-  <pose>0 0 0 0 0 0</pose>
-  <link name="link">
-    <collision name="collision">
-      <geometry>
-        <box>
-          <size>.5 .5 1.5</size>
-        </box>
-      </geometry>
-    </collision>
+  <model name="actor_model">
+    <pose>0 0 0 0 0 0</pose>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <box>
+            <size>.5 .5 1.5</size>
+          </box>
+        </geometry>
+      </collision>
 
-    <visual name="visual">
-      <geometry>
-        <box>
-          <size>.5 .5 1.5</size>
-        </box>
-      </geometry>
-    </visual>
+      <visual name="visual">
+        <geometry>
+          <box>
+            <size>.5 .5 1.5</size>
+          </box>
+        </geometry>
+      </visual>
 
-  </link>
-</model>
+    </link>
+  </model>
 
 
-<!--<model name="actor_model">
+  <!--<model name="actor_model">
   <link name="link">
     <collision name="collision">
       <pose>0 0 0 1.5708 0 0</pose>
@@ -46,9 +46,6 @@
     </visual>
   </link>
 </model>-->
-
-
-
 
 
 </sdf>

--- a/pedsim_gazebo_plugin/models/actor_model.sdf
+++ b/pedsim_gazebo_plugin/models/actor_model.sdf
@@ -3,7 +3,7 @@
 
 
 <model name="actor_model">
-  <pose>0 0 0 0 0 0</pose>
+  <pose>0 0 0.75 0 0 0</pose>
   <link name="link">
     <collision name="collision">
       <geometry>

--- a/pedsim_gazebo_plugin/models/actor_model.sdf
+++ b/pedsim_gazebo_plugin/models/actor_model.sdf
@@ -2,30 +2,30 @@
 <sdf version="1.5">
 
 
-  <model name="actor_model">
-    <pose>0 0 0 0 0 0</pose>
-    <link name="link">
-      <collision name="collision">
-        <geometry>
-          <box>
-            <size>.5 .5 1.5</size>
-          </box>
-        </geometry>
-      </collision>
+<model name="actor_model">
+  <pose>0 0 0 0 0 0</pose>
+  <link name="link">
+    <collision name="collision">
+      <geometry>
+        <box>
+          <size>.5 .5 1.5</size>
+        </box>
+      </geometry>
+    </collision>
 
-      <visual name="visual">
-        <geometry>
-          <box>
-            <size>.5 .5 1.5</size>
-          </box>
-        </geometry>
-      </visual>
+    <visual name="visual">
+      <geometry>
+        <box>
+          <size>.5 .5 1.5</size>
+        </box>
+      </geometry>
+    </visual>
 
-    </link>
-  </model>
+  </link>
+</model>
 
 
-  <!--<model name="actor_model">
+<!--<model name="actor_model">
   <link name="link">
     <collision name="collision">
       <pose>0 0 0 1.5708 0 0</pose>
@@ -46,6 +46,9 @@
     </visual>
   </link>
 </model>-->
+
+
+
 
 
 </sdf>

--- a/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
+++ b/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
@@ -56,7 +56,7 @@ namespace gazebo
                             ignition::math::Pose3d gzb_pose;
                             gzb_pose.Pos().Set( msg->agent_states[actor].pose.position.x,
                                                 msg->agent_states[actor].pose.position.y,
-                                                msg->agent_states[actor].pose.position.z);
+                                                msg->agent_states[actor].pose.position.z + MODEL_OFFSET);
                             gzb_pose.Rot().Set(msg->agent_states[actor].pose.orientation.w,
                                                msg->agent_states[actor].pose.orientation.x,
                                                msg->agent_states[actor].pose.orientation.y,
@@ -90,6 +90,7 @@ namespace gazebo
         std::thread rosQueueThread;
         physics::WorldPtr world_;
         event::ConnectionPtr updateConnection_;
+        const float MODEL_OFFSET = 0.75; 
 
     };
     GZ_REGISTER_WORLD_PLUGIN(ActorPosesPlugin)

--- a/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
+++ b/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
@@ -44,6 +44,7 @@ namespace gazebo
             void OnRosMsg( const pedsim_msgs::AgentStatesConstPtr msg) {
 //              ROS_INFO ("OnRosMsg ... ");
                 std::string model_name;
+                const float MODEL_OFFSET = 0.75; 
                 for(unsigned int mdl = 0; mdl < world_->ModelCount(); mdl++) {
                     physics::ModelPtr  tmp_model;
                     tmp_model = world_->ModelByIndex(mdl);
@@ -56,7 +57,7 @@ namespace gazebo
                             ignition::math::Pose3d gzb_pose;
                             gzb_pose.Pos().Set( msg->agent_states[actor].pose.position.x,
                                                 msg->agent_states[actor].pose.position.y,
-                                                msg->agent_states[actor].pose.position.z);
+                                                msg->agent_states[actor].pose.position.z + MODEL_OFFSET);
                             gzb_pose.Rot().Set(msg->agent_states[actor].pose.orientation.w,
                                                msg->agent_states[actor].pose.orientation.x,
                                                msg->agent_states[actor].pose.orientation.y,

--- a/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
+++ b/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
@@ -44,7 +44,6 @@ namespace gazebo
             void OnRosMsg( const pedsim_msgs::AgentStatesConstPtr msg) {
 //              ROS_INFO ("OnRosMsg ... ");
                 std::string model_name;
-                const float MODEL_OFFSET = 0.75; 
                 for(unsigned int mdl = 0; mdl < world_->ModelCount(); mdl++) {
                     physics::ModelPtr  tmp_model;
                     tmp_model = world_->ModelByIndex(mdl);
@@ -57,7 +56,7 @@ namespace gazebo
                             ignition::math::Pose3d gzb_pose;
                             gzb_pose.Pos().Set( msg->agent_states[actor].pose.position.x,
                                                 msg->agent_states[actor].pose.position.y,
-                                                msg->agent_states[actor].pose.position.z + MODEL_OFFSET);
+                                                msg->agent_states[actor].pose.position.z);
                             gzb_pose.Rot().Set(msg->agent_states[actor].pose.orientation.w,
                                                msg->agent_states[actor].pose.orientation.x,
                                                msg->agent_states[actor].pose.orientation.y,


### PR DESCRIPTION
There was a problem #51 that 3D model of pedestrian was shaky up and down when showing pedestrian on gazebo with pedsim_gazebo_plugin.
When I added half of the model's height to the pose.z as an offset, the problem seemed to be temporarily solved.
However, this method depends on the model represented by the current cube, so if you change the 3D model to something else, you'll have to change it.