### PR TITLE
Fix gazebo model direction

### DIFF
--- a/pedsim_gazebo_plugin/CMakeLists.txt
+++ b/pedsim_gazebo_plugin/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   gazebo_msgs
   pedsim_msgs
+  pedsim_utils
 )
 
 ## System dependencies are found with CMake's conventions
@@ -40,7 +41,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES gzb_vel_plugin
-  CATKIN_DEPENDS gazebo_ros roscpp  geometry_msgs pedsim_msgs
+  CATKIN_DEPENDS gazebo_ros roscpp  geometry_msgs pedsim_msgs pedsim_utils
 #  DEPENDS system_lib
 )
 

--- a/pedsim_gazebo_plugin/CMakeLists.txt
+++ b/pedsim_gazebo_plugin/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
   gazebo_msgs
   pedsim_msgs
-  pedsim_utils
 )
 
 ## System dependencies are found with CMake's conventions
@@ -41,7 +40,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES gzb_vel_plugin
-  CATKIN_DEPENDS gazebo_ros roscpp  geometry_msgs pedsim_msgs pedsim_utils
+  CATKIN_DEPENDS gazebo_ros roscpp  geometry_msgs pedsim_msgs 
 #  DEPENDS system_lib
 )
 

--- a/pedsim_gazebo_plugin/package.xml
+++ b/pedsim_gazebo_plugin/package.xml
@@ -13,23 +13,23 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>gazebo_ros</build_depend>
   <build_depend>roscpp</build_depend>
-
+  <build_depend>pedsim_utils</build_depend>
 
 <build_depend>pedsim_msgs</build_depend>
 <build_depend>geometry_msgs</build_depend>
-
 
   <build_export_depend>gazebo_ros</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>pedsim_msgs</build_export_depend>
+  <build_export_depend>pedsim_utils</build_export_depend>
 
 
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>pedsim_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-
+  <exec_depend>pedsim_utils</exec_depend>
   <export>
 
   </export>

--- a/pedsim_gazebo_plugin/package.xml
+++ b/pedsim_gazebo_plugin/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>gazebo_ros</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>pedsim_utils</build_depend>
 
 <build_depend>pedsim_msgs</build_depend>
 <build_depend>geometry_msgs</build_depend>
@@ -22,14 +21,12 @@
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>pedsim_msgs</build_export_depend>
-  <build_export_depend>pedsim_utils</build_export_depend>
 
 
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>pedsim_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>pedsim_utils</exec_depend>
   <export>
 
   </export>

--- a/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
+++ b/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
@@ -15,7 +15,7 @@ Created on Mon Dec  2
 
 #include<pedsim_msgs/TrackedPersons.h>
 #include<pedsim_msgs/AgentStates.h>
-
+ #include <pedsim_utils/geometry.h>
 
 
 namespace gazebo
@@ -61,6 +61,11 @@ namespace gazebo
                                                msg->agent_states[actor].pose.orientation.x,
                                                msg->agent_states[actor].pose.orientation.y,
                                                msg->agent_states[actor].pose.orientation.z);
+                                                        auto theta =
+                            std::atan2(agent_state.twist.linear.y, agent_state.twist.linear.x);
+                            auto quaternion = pedsim::angleToQuaternion(theta);
+                            gzb_pose.Rot().Set(
+                              quaternion.w, quaternion.x, quaternion.y, quaternion.z);
                             try{
                                 tmp_model->SetWorldPose(gzb_pose);
                             }

--- a/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
+++ b/pedsim_gazebo_plugin/src/actor_poses_plugin.cpp
@@ -15,7 +15,6 @@ Created on Mon Dec  2
 
 #include<pedsim_msgs/TrackedPersons.h>
 #include<pedsim_msgs/AgentStates.h>
- #include <pedsim_utils/geometry.h>
 
 
 namespace gazebo
@@ -61,11 +60,7 @@ namespace gazebo
                                                msg->agent_states[actor].pose.orientation.x,
                                                msg->agent_states[actor].pose.orientation.y,
                                                msg->agent_states[actor].pose.orientation.z);
-                                                        auto theta =
-                            std::atan2(agent_state.twist.linear.y, agent_state.twist.linear.x);
-                            auto quaternion = pedsim::angleToQuaternion(theta);
-                            gzb_pose.Rot().Set(
-                              quaternion.w, quaternion.x, quaternion.y, quaternion.z);
+
                             try{
                                 tmp_model->SetWorldPose(gzb_pose);
                             }

--- a/pedsim_simulator/src/simulator.cpp
+++ b/pedsim_simulator/src/simulator.cpp
@@ -296,6 +296,8 @@ void Simulator::publishAgents() {
     state.pose.position.x = a->getx();
     state.pose.position.y = a->gety();
     state.pose.position.z = a->getz();
+    auto theta = std::atan2(a->getvy(), a->getvx());
+    state.pose.orientation = pedsim::angleToQuaternion(theta);
 
     state.twist.linear.x = a->getvx();
     state.twist.linear.y = a->getvy();


### PR DESCRIPTION
Solved the problem shown in #53 where Gazebo's 3D model is always facing the same direction, which was due to the fact that there was no value in ``AgentState``'s ``pose.orientation`` in the first place.
I've modified the code by referring to this.
https://github.com/srl-freiburg/pedsim_ros/blob/b21218347149657f0639ada23da8847f537811ce/pedsim_visualizer/src/sim_visualizer.cpp#L98