### PR TITLE
Add lifetime to force markers.

### DIFF
--- a/pedsim_visualizer/include/pedsim_visualizer/sim_visualizer.h
+++ b/pedsim_visualizer/include/pedsim_visualizer/sim_visualizer.h
@@ -104,6 +104,7 @@ class SimVisualizer {
   void setupPublishersAndSubscribers();
 
   ros::NodeHandle nh_;
+  double hz_;
 
   /// publishers
   ros::Publisher pub_obstacles_visuals_;

--- a/pedsim_visualizer/src/sim_visualizer.cpp
+++ b/pedsim_visualizer/src/sim_visualizer.cpp
@@ -34,8 +34,14 @@
 
 namespace pedsim {
 
+const static double DEFAULT_VIZ_HZ = 25.0;
+
 SimVisualizer::SimVisualizer(const ros::NodeHandle& node_in) : nh_{node_in} {
   setupPublishersAndSubscribers();
+  nh_.param<double>("hz", hz_, DEFAULT_VIZ_HZ);
+  if (hz_ < 0) {
+    hz_ = DEFAULT_VIZ_HZ;
+  }
 }
 SimVisualizer::~SimVisualizer() {
   pub_obstacles_visuals_.shutdown();
@@ -50,7 +56,7 @@ SimVisualizer::~SimVisualizer() {
 }
 
 void SimVisualizer::run() {
-  ros::Rate r(25.);
+  ros::Rate r(hz_);
 
   while (ros::ok()) {
     publishAgentVisuals();
@@ -96,6 +102,7 @@ void SimVisualizer::publishAgentVisuals() {
   force_marker.header = current_states->header;
   force_marker.type = visualization_msgs::Marker::ARROW;
   force_marker.action = visualization_msgs::Marker::ADD;
+  force_marker.lifetime = ros::Duration(1.0 / hz_);
   force_marker.scale.x = 0.05; // shaft diameter
   force_marker.scale.y = 0.1; // head diameter
   force_marker.scale.z = 0.3; // head length


### PR DESCRIPTION
This PR fixes a visualization issue due to the force markers: when a pedestrian disappear at a sink waypoint, the forces arrows would not be deleted.

Before:
![before](https://user-images.githubusercontent.com/66578286/93039895-ad7cb000-f683-11ea-85d7-8534a893276e.gif)

After:
![after](https://user-images.githubusercontent.com/66578286/93039905-b3729100-f683-11ea-9182-dcf0434aa77a.gif)

