### PR TITLE
Integration of ros_maps_to_pedsim for ROS map conversion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "2ndparty/spencer_tracking_rviz_plugin"]
 	path = 2ndparty/spencer_tracking_rviz_plugin
 	url = https://github.com/srl-freiburg/spencer_tracking_rviz_plugin.git
+[submodule "3rdparty/ros_maps_to_pedsim"]
+	path = 3rdparty/ros_maps_to_pedsim
+	url = https://github.com/fverdoja/ros_maps_to_pedsim.git

--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(libpedsim)
+add_subdirectory(ros_maps_to_pedsim)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ catkin build -c  # or catkin_make
 ```
 roslaunch pedsim_simulator simple_pedestrians.launch
 ```
+
+### How to use with ROS maps
+In order to converts maps in ROS format (as defined by `map_server`) to Pedsim scenarios, check out the `3rdparty/ros_maps_to_pedsim` package and the included [README](3rdparty/ros_maps_to_pedsim/README.md) for more details.
+
+
 ### Licence
 The core `libpedsim` is licensed under LGPL. The ROS integration and extensions are licensed under BSD.
 
@@ -47,6 +52,7 @@ The core `libpedsim` is licensed under LGPL. The ROS integration and extensions 
 * Sven Wehner
 * Omar Islas
 * Luigi Palmieri
+* Francesco Verdoja
 
 The package is a **work in progress** mainly used in research prototyping. Pull requests and/or issues are highly encouraged.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ roslaunch pedsim_simulator simple_pedestrians.launch
 ```
 
 ### How to use with ROS maps
-In order to converts maps in ROS format (as defined by `map_server`) to Pedsim scenarios, check out the `3rdparty/ros_maps_to_pedsim` package and the included [README](3rdparty/ros_maps_to_pedsim/README.md) for more details.
+In order to converts maps in ROS format (as defined by `map_server`) to Pedsim scenarios, check out the `3rdparty/ros_maps_to_pedsim` package and the included [README](https://github.com/fverdoja/ros_maps_to_pedsim/blob/main/README.md) for more details.
 
 
 ### Licence

--- a/pedsim_visualizer/include/pedsim_visualizer/sim_visualizer.h
+++ b/pedsim_visualizer/include/pedsim_visualizer/sim_visualizer.h
@@ -105,6 +105,7 @@ class SimVisualizer {
 
   ros::NodeHandle nh_;
   double hz_;
+  double walls_marker_scale_;
 
   /// publishers
   ros::Publisher pub_obstacles_visuals_;

--- a/pedsim_visualizer/src/sim_visualizer.cpp
+++ b/pedsim_visualizer/src/sim_visualizer.cpp
@@ -35,12 +35,18 @@
 namespace pedsim {
 
 const static double DEFAULT_VIZ_HZ = 25.0;
+const static double DEFAULT_WALL_MARKER_SCALE = 1.0;
 
 SimVisualizer::SimVisualizer(const ros::NodeHandle& node_in) : nh_{node_in} {
   setupPublishersAndSubscribers();
   nh_.param<double>("hz", hz_, DEFAULT_VIZ_HZ);
+  nh_.param<double>("walls_marker_scale", walls_marker_scale_,
+                    DEFAULT_WALL_MARKER_SCALE);
   if (hz_ < 0) {
     hz_ = DEFAULT_VIZ_HZ;
+  }
+  if (walls_marker_scale_ < 0) {
+    walls_marker_scale_ = DEFAULT_WALL_MARKER_SCALE;
   }
 }
 SimVisualizer::~SimVisualizer() {
@@ -226,8 +232,8 @@ void SimVisualizer::publishObstacleVisuals() {
   walls_marker.color.r = 0.647059;
   walls_marker.color.g = 0.164706;
   walls_marker.color.b = 0.164706;
-  walls_marker.scale.x = 1.0;
-  walls_marker.scale.y = 1.0;
+  walls_marker.scale.x = walls_marker_scale_;
+  walls_marker.scale.y = walls_marker_scale_;
   walls_marker.scale.z = 2.0;
   walls_marker.pose.position.z = walls_marker.scale.z / 2.0;
   walls_marker.pose.orientation.w = 1.0;


### PR DESCRIPTION
This PR addresses #38 and follows from the discussion there.

* added the package `ros_maps_to_pedsim` as submodule in _3rdparty_,
* added a reference to the package in the `README.md`
* added an extra ROS param to sim_visualizer to change `wall_marker_scale`. The default of the `wall_marker_scale` param is left to 1.0m for compatibility with the rest of the codebase.